### PR TITLE
Update availability_blacklist and availability_whitelist to allow for friendly names

### DIFF
--- a/lib/extension/deviceAvailability.js
+++ b/lib/extension/deviceAvailability.js
@@ -37,13 +37,18 @@ class DeviceAvailability extends BaseExtension {
     }
 
     isAllowed(device) {
+        const ieeeAddr = device.ieeeAddr;
+
+        const deviceSettings = settings.getDevice(ieeeAddr);
+        const name = deviceSettings ? deviceSettings.friendly_name : ieeeAddr;
+
         // Whitelist is not empty and device is in it, enable availability
         if (this.whitelist.length > 0) {
-            return this.whitelist.includes(device.ieeeAddr);
+            return this.whitelist.includes(name);
         }
 
         // Device is on blacklist, disable availability
-        if (this.blacklist.includes(device.ieeeAddr)) {
+        if (this.blacklist.includes(name)) {
             return false;
         }
 


### PR DESCRIPTION
The documentation currently suggests that the `availability_blacklist` and `availability_whitelist` arrays should contain device friendly names: https://www.zigbee2mqtt.io/information/configuration.html. However, this doesn't currently work.

This PR updates the code to use friendly names if available, or default back to the IEEE address if not.